### PR TITLE
Stops opening jira tickets for non-prm and non-compliance emails [PD-1005]

### DIFF
--- a/.landscape.yaml
+++ b/.landscape.yaml
@@ -1,0 +1,2 @@
+ignore-patterns:
+    - (^|/)migrations(/|$)

--- a/redirect/helpers.py
+++ b/redirect/helpers.py
@@ -488,7 +488,7 @@ def add_part(body, part, value, join_str):
     return body
 
 
-def log_failure(post, subject=None):
+def log_failure(post, subject):
     """
     Logs failures in redirecting job@my.jobs emails. This does not mean literal
     failure, but the email in question is not a guid@my.jobs email and should
@@ -531,8 +531,6 @@ def log_failure(post, subject=None):
 
     body = add_part(body, 'headers', headers, '\n')
 
-    if subject is None:
-        subject = 'My.jobs contact email'
     if jira:
         project = jira.project('MJA')
         issue = {

--- a/redirect/tests/test_views.py
+++ b/redirect/tests/test_views.py
@@ -990,14 +990,7 @@ class EmailForwardTests(TestCase):
     def test_bad_email(self):
         self.submit_email()
 
-        email = mail.outbox.pop()
-        for field in [self.post_dict['to'][0], self.post_dict['from']]:
-            self.assertTrue(field in email.body)
-
-        self.assertEqual(email.from_email, self.post_dict['from'])
-        self.assertEqual(email.to, [settings.EMAIL_TO_ADMIN])
-        self.assertEqual(email.subject, 'My.jobs contact email')
-        self.assertTrue(self.post_dict['text'] in email.body)
+        self.assertEqual(len(mail.outbox), 0)
 
     def test_bad_guid_email(self):
         self.post_dict['to'] = '%s@my.jobs' % ('1'*32)
@@ -1068,16 +1061,14 @@ class EmailForwardTests(TestCase):
 
         self.submit_email()
 
-        email = mail.outbox.pop()
-        self.assertTrue('My.jobs contact email' in email.subject)
+        self.assertEqual(len(mail.outbox), 0)
 
     def test_too_many_emails(self):
         self.post_dict['to'] = 'test@example.com, foo@mail.my.jobs'
 
         self.submit_email()
 
-        email = mail.outbox.pop()
-        self.assertTrue('My.jobs contact email' in email.subject)
+        self.assertEqual(len(mail.outbox), 0)
 
     def test_prm_email(self):
         """


### PR DESCRIPTION
The only things that should get logged to Jira are emails with weird attachments. We can probably get rid of that as well if no one thinks it's useful.

All tests pass.