### PR TITLE
Add ReqID and job description to member emails <PD-1288>

### DIFF
--- a/redirect/helpers.py
+++ b/redirect/helpers.py
@@ -588,7 +588,8 @@ def get_job_from_solr(guid):
     return None
 
 
-def send_response_to_sender(new_to, old_to, email_type, guid='', job=None):
+def send_response_to_sender(new_to, old_to, email_type, guid='', job=None,
+                            solr_job=None):
     """
     Send response to guid@my.jobs emails
 
@@ -611,7 +612,6 @@ def send_response_to_sender(new_to, old_to, email_type, guid='', job=None):
     else:
         to_parts = getaddresses(new_to)
         to = to_parts[0][0] or to_parts[0][1]
-        solr_job = get_job_from_solr(guid)
         title = ''
         description = ''
         if solr_job is not None:

--- a/redirect/views.py
+++ b/redirect/views.py
@@ -292,7 +292,7 @@ def email_redirect(request):
                         if solr_job
                         else u"This job ({title}) has expired.".format(
                             title=job.title))
-    body = "\n".join([body, dashes, description])
+    body = "\r\n\r\n".join([body, dashes, description])
     html_body = "<br />".join([html_body, dashes, html_description])
 
     # We reached this point; the data should be good

--- a/redirect/views.py
+++ b/redirect/views.py
@@ -288,8 +288,12 @@ def email_redirect(request):
                    if solr_job
                    else u"This job ({title}) has expired.".format(
                        title=job.title))
+    html_description = (solr_job.get('html_description')
+                        if solr_job
+                        else u"This job ({title}) has expired.".format(
+                            title=job.title))
     body = "\n".join([body, dashes, description])
-    html_body = "<br />".join([html_body, dashes, description])
+    html_body = "<br />".join([html_body, dashes, html_description])
 
     # We reached this point; the data should be good
     email = EmailMultiAlternatives(

--- a/redirect/views.py
+++ b/redirect/views.py
@@ -15,6 +15,7 @@ from django.template import RequestContext
 from django.template.loader import render_to_string
 from django.utils import text, timezone
 from django.views.decorators.csrf import csrf_exempt
+from redirect.helpers import get_job_from_solr
 
 from redirect.models import (Redirect, CanonicalMicrosite,
                              DestinationManipulation, CompanyEmail,
@@ -257,6 +258,8 @@ def email_redirect(request):
         helpers.send_response_to_sender(**email_dict)
         return HttpResponse(status=200)
 
+    solr_job = get_job_from_solr(hex_guid)
+    email_dict['solr_job'] = solr_job
     email_dict['job'] = job
 
     try:
@@ -273,6 +276,20 @@ def email_redirect(request):
     sg_headers = {
         'X-SMTPAPI': '{"category": "My.jobs email redirect"}'
     }
+
+    reqid = solr_job.get('reqid', 'None') if solr_job else 'Expired'
+    subject = u'[ReqID: {reqid}] - {subject}'.format(
+        reqid=reqid, subject=subject)
+
+    # We want to ensure both text and html emails get sent, hence what could
+    # be considered a bit of duplication.
+    dashes = "----------------------"
+    description = (solr_job.get('description')
+                   if solr_job
+                   else u"This job ({title}) has expired.".format(
+                       title=job.title))
+    body = "\n".join([body, dashes, description])
+    html_body = "<br />".join([body, dashes, description])
 
     # We reached this point; the data should be good
     email = EmailMultiAlternatives(

--- a/redirect/views.py
+++ b/redirect/views.py
@@ -289,7 +289,7 @@ def email_redirect(request):
                    else u"This job ({title}) has expired.".format(
                        title=job.title))
     body = "\n".join([body, dashes, description])
-    html_body = "<br />".join([body, dashes, description])
+    html_body = "<br />".join([html_body, dashes, description])
 
     # We reached this point; the data should be good
     email = EmailMultiAlternatives(


### PR DESCRIPTION
Doing this raised some issues that have existed for a while now. I was unable to run tests as the migration for User has been wiped out to keep it from interfering with our canonical User model. The best solution is probably to merge MyJobs-urls into MyJobs and do away with having user be defined in multiple places.

As such, I can't run tests. As you can see, however, I'm just manipulating strings. If that's not good enough, we'll need to put this off until the projects are merged or whatever we decide to do.